### PR TITLE
Locker/timeout (Deadlocks Guard)

### DIFF
--- a/cmd/candi/template_env.go
+++ b/cmd/candi/template_env.go
@@ -5,6 +5,7 @@ ENVIRONMENT=development #development,staging,production
 DEBUG_MODE=true
 NO_AUTH=true
 LOAD_CONFIG_TIMEOUT=20s
+LOCKER_TIMEOUT=10s
 
 # Application Service Handlers
 ## Server

--- a/config/env/environment.go
+++ b/config/env/environment.go
@@ -23,6 +23,8 @@ type Env struct {
 	Environment       string
 	LoadConfigTimeout time.Duration
 
+	LockerTimeout time.Duration
+
 	useSQL, useMongo, useRedis, useRSAKey bool
 	NoAuth                                bool
 	UseSharedListener                     bool
@@ -136,6 +138,12 @@ func Load(serviceName string) {
 
 	if env.LoadConfigTimeout, err = time.ParseDuration(os.Getenv("LOAD_CONFIG_TIMEOUT")); err != nil {
 		env.LoadConfigTimeout = 10 * time.Second // default value
+	}
+
+	if env.LockerTimeout, err = time.ParseDuration(os.Getenv("LOCKER_TIMEOUT")); err != nil {
+		// locker timeout value = 10
+		// assuming the maximum response time service tolerance that we make = 1-2 seconds
+		env.LockerTimeout = 10 * time.Second
 	}
 
 	// ------------------------------------


### PR DESCRIPTION
This pull request aims to fulfill the rules of the distributed lock,
- in a distributed key, each entity (instance/pod) that creates the key is responsible for deleting the key
- what happens if the entity(instance/pods) that created that lock restarts or dies suddenly?

by adding a timeout to each key locker that is made the possibility of deadlocks can be minimized. Assuming the tolerance for each function, code section, or external service call is under 10 seconds. According to the LOCKER_TIMEOUT configuration in the env variable

the rest is open for discussion cc: @agungdwiprasetyo 