### PR TITLE
BUGFIX: add error variable to handle context not updated

### DIFF
--- a/codebase/app/grpc_server/interceptor.go
+++ b/codebase/app/grpc_server/interceptor.go
@@ -178,9 +178,11 @@ func (i *interceptor) streamMiddlewareInterceptor(srv interface{}, stream grpc.S
 }
 
 func (i *interceptor) middlewareInterceptor(ctx context.Context, fullMethod string) (context.Context, error) {
+	var err error
+	
 	if middFunc, ok := i.middleware[fullMethod]; ok {
 		for _, mw := range middFunc {
-			ctx, err := mw(ctx)
+			ctx, err = mw(ctx)
 			if err != nil {
 				return ctx, err
 			}


### PR DESCRIPTION
Hello Team Dev Golang Candi,

I want to raise a bug in the middleware interceptor, in the previous code, the context was not updated because it was newly initiated using ( := ), so when in the looping process the context value was not passed to the next middleware. I hope this bug can be fixed soon. Because I like using this framework.

And Also I'd like to suggest new feature, which is grpc server reflection, so the grpc can be tested in postman. Thank You

Best Regards


Rodericus Ifo Krista