### PR TITLE
add new tag to set env as optional

### DIFF
--- a/candihelper/helper.go
+++ b/candihelper/helper.go
@@ -191,7 +191,9 @@ func MustParseEnv(target interface{}) {
 
 		val, ok := os.LookupEnv(key)
 		if !ok {
-			mErrs.Append(key, fmt.Errorf("missing %s environment", key))
+			if typ.Tag.Get("optional") != "true" {
+				mErrs.Append(key, fmt.Errorf("missing %s environment", key))
+			}
 			continue
 		}
 


### PR DESCRIPTION
Sometimes we may want to simplify the `.env` file by removing unused variables, but we can be hesitant to do so because we don't want to affect the related logic in the code. Currently, we need to set all required variables for the app to run. 

However, with this new implementation, you can now make certain variables optional by simply adding the optional tag to the environment declaration in `pkg/shared/environment.go`. This means you can safely remove those optional variables from the `.env` file without breaking the app.

Here's an example implementation:

```
pkg/shared/environment.go
....
ExampleOptionalEnv string `env:"EXAMPLE_OPTIONAL_ENV" optional:"true"`
...
```

By implementing this change, you can now simplify your `.env` file and make it easier to manage your app's environment variables.