### PR TITLE
task-queue-worker: bugfix command to get mongo version

### DIFF
--- a/codebase/app/task_queue_worker/persistent_mongo.go
+++ b/codebase/app/task_queue_worker/persistent_mongo.go
@@ -597,7 +597,7 @@ func (s *MongoPersistent) Type() string {
 	var commandResult struct {
 		Version string `bson:"version"`
 	}
-	err := s.db.RunCommand(s.ctx, bson.D{{Key: "serverStatus", Value: 1}}).Decode(&commandResult)
+	err := s.db.RunCommand(s.ctx, bson.D{{Key: "buildInfo", Value: 1}}).Decode(&commandResult)
 	logger.LogIfError(err)
 	if commandResult.Version != "" {
 		commandResult.Version = ", version: " + commandResult.Version


### PR DESCRIPTION
Try to fix issue get version of mongo db

`[MongoServerError[Unauthorized]:] not authorized on db_name to execute command { serverStatus: 1, lsid: {}, $clusterTime: { clusterTime: Timestamp(1716964746, 3402), signature: { hash: BinData(), keyId: xxx } }, $db: "db_name" }`


Change command from `db.runCommand( { serverStatus: 1 } )` to `db.runCommand( { buildInfo: 1 } )`