### PR TITLE
Add fuction database update tool to extract sql tag

### DIFF
--- a/candishared/database_update_tools.go
+++ b/candishared/database_update_tools.go
@@ -58,6 +58,15 @@ func DBUpdateMongoExtractorKey(structField reflect.StructField) (string, bool) {
 	return candihelper.ToDelimited(structField.Name, '_'), false
 }
 
+// DBUpdateSqlExtractorKey struct field key extractor for mongo model
+func DBUpdateSqlExtractorKey(structField reflect.StructField) (string, bool) {
+	sqlTag := structField.Tag.Get("sql")
+	if strings.HasPrefix(sqlTag, "column:") {
+		return strings.Split(strings.TrimPrefix(sqlTag, "column:"), ";")[0], false
+	}
+	return candihelper.ToDelimited(structField.Name, '_'), false
+}
+
 // DBUpdateTools for construct selected field to update
 type DBUpdateTools struct {
 	KeyExtractorFunc    func(structTag reflect.StructField) (key string, mustSet bool)

--- a/candishared/database_update_tools_test.go
+++ b/candishared/database_update_tools_test.go
@@ -114,3 +114,70 @@ func TestDBUpdateToolsMongo(t *testing.T) {
 	)
 	assert.Equal(t, 9, len(updated))
 }
+
+func TestDBUpdateSqlExtractorKey(t *testing.T) {
+	type SubModel struct {
+		Title       string       `sql:"column:title" json:"title"`
+		Profile     string       `sql:"column:profile" json:"profile"`
+		ActivatedAt sql.NullTime `sql:"column:activated_at" json:"activatedAt"`
+		CityAddress string       `sql:"type:text"`
+	}
+	type Model struct {
+		ID        int     `sql:"column:id;" json:"id"`
+		Name      *string `sql:"column:name;" json:"name"`
+		Address   string  `sql:"column:alamat" json:"address"`
+		No        int
+		CreatedAt time.Time
+		IgnoreMe  SubModel `sql:"column:test" json:"ignoreMe" ignoreUpdate:"true"`
+		Rel       SubModel `sql:"foreignKey:ID" json:"rel"`
+		Log       []byte
+		StrArr    pq.StringArray
+		IntArr    pq.Int64Array
+		Ch        chan string
+		Multi     []SubModel
+		Map       map[int]SubModel
+		PtrModel  *SubModel
+		DeletedAt *time.Time
+		NamedArg  *sql.NamedArg
+		SubModel
+	}
+	var updated map[string]any
+
+	updated = DBUpdateTools{KeyExtractorFunc: DBUpdateSqlExtractorKey}.ToMap(
+		&Model{ID: 1, Name: candihelper.ToStringPtr("01"), Address: "street",
+			SubModel: SubModel{Title: "test", CityAddress: "Jakarta"}, Rel: SubModel{Title: "rel sub"}},
+		DBUpdateSetUpdatedFields("ID", "Name", "Title", "CityAddress", "Address"),
+	)
+
+	assert.Equal(t, 5, len(updated))
+	assert.Equal(t, 1, updated["id"])
+	assert.Equal(t, "01", updated["name"])
+	assert.Equal(t, "test", updated["title"])
+	assert.Equal(t, "Jakarta", updated["city_address"])
+
+	updated = DBUpdateTools{KeyExtractorFunc: DBUpdateSqlExtractorKey}.ToMap(
+		Model{ID: 1, Name: candihelper.ToStringPtr("01"), Address: "street", SubModel: SubModel{Title: "test", ActivatedAt: sql.NullTime{Valid: true}}},
+		DBUpdateSetIgnoredFields("ID", "Name", "Title"),
+	)
+	assert.Equal(t, 10, len(updated))
+	assert.Equal(t, "street", updated["alamat"])
+
+	updated = DBUpdateTools{KeyExtractorFunc: DBUpdateSqlExtractorKey}.ToMap(
+		Model{
+			No:        10,
+			Multi:     make([]SubModel, 1),
+			Rel:       SubModel{Title: "001"},
+			CreatedAt: time.Now(),
+			SubModel:  SubModel{ActivatedAt: sql.NullTime{Valid: true, Time: time.Now()}, CityAddress: "Jakarta"},
+			PtrModel:  &SubModel{CityAddress: "New"},
+			Log:       []byte(`123`),
+			StrArr:    pq.StringArray{"1", "2", "3"},
+			IntArr:    pq.Int64Array{1, 2, 3},
+		},
+	)
+	assert.Equal(t, 13, len(updated))
+	assert.Equal(t, "Jakarta", updated["city_address"])
+	assert.Equal(t, 10, updated["no"])
+	assert.Equal(t, "{\"1\",\"2\",\"3\"}", updated["str_arr"])
+	assert.Equal(t, []byte(`123`), updated["log"])
+}


### PR DESCRIPTION
This function used for extract the column name on struct  tag `sql` with prefix `column:`

```
type Model struct {
	ID      int    `sql:"column:id;" json:"id"`
	Name    string `sql:"column:name;" json:"name"`
	Address string `sql:"column:address" json:"address"`
}

type Repository interface {
	Update(ctx context.Context, data *Model) error
}

type sqlRepo struct {
	updateTool *DBUpdateTools
}

func NewSQLRepo() Repository {
	return &sqlRepo{
		updateTool: &DBUpdateTools{
			KeyExtractorFunc: DBUpdateSqlExtractorKey,
		},
	}
}

func (s *sqlRepo) Update(ctx context.Context, data *Model) error {

	data = &Model{
		ID:      1,
		Name:    "John",
		Address: "Indonesia",
	}

	updated := s.updateTool.ToMap(data)

	return nil
}
```