### PR TITLE
Locker: add option function locker with time to live

### DIFF
--- a/codebase/interfaces/locker.go
+++ b/codebase/interfaces/locker.go
@@ -6,6 +6,7 @@ type (
 	// Locker abstraction, lock concurrent process
 	Locker interface {
 		IsLocked(key string) bool
+		IsLockedWithTTL(key string, timeout time.Duration) bool
 		HasBeenLocked(key string) bool
 		Unlock(key string)
 		Reset(key string)


### PR DESCRIPTION
Additional optional function for IsLocker that uses time to live, to protect in case there is a need for service down but the key remains in redis.