### PR TITLE
rest middleware: add trace_id into the log buffer

### DIFF
--- a/codebase/app/rest_server/middleware.go
+++ b/codebase/app/rest_server/middleware.go
@@ -216,6 +216,9 @@ func HTTPMiddlewareTracer() func(http.Handler) http.Handler {
 			logBuff.WriteString(`,"latency":"`)
 			logBuff.WriteString(stop.Sub(start).String())
 
+			logBuff.WriteString(`","trace_id":"`)
+			logBuff.WriteString(tracer.GetTraceID(ctx))
+
 			logBuff.WriteString(`","bytes_in":`)
 			cl := req.Header.Get("Content-Length")
 			if cl == "" {


### PR DESCRIPTION
**What does this PR do?**
This PR enhances our logging mechanism by including the `trace_id `in the log output. This improvement allows us to trace requests more effectively.

**Why is this change necessary?**
Currently, tracing requests based on the `trace_id `from the console output is challenging if the `trace_id `is not readily available. By adding the `trace_id `to the log output, we can easily retrieve and analyze request details.

**Additional Notes**
- This change does not affect the existing functionality but enhances the logging for better traceability.
- Ensure that the tracer is properly initialized in the context.