### PR TITLE
dependencies: upgrade JWT version to v5 due to CVE-2024-51744

### DIFF
--- a/candishared/token_claim_payload.go
+++ b/candishared/token_claim_payload.go
@@ -1,10 +1,10 @@
 package candishared
 
-import "github.com/golang-jwt/jwt"
+import "github.com/golang-jwt/jwt/v5"
 
 // TokenClaim for token claim data
 type TokenClaim struct {
-	jwt.StandardClaims
-	Role       string      `json:"role"`
-	Additional any `json:"additional"`
+	jwt.RegisteredClaims
+	Role       string `json:"role"`
+	Additional any    `json:"additional"`
 }

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/golangid/candi
 
-go 1.23
+go 1.23.3
 
 require (
 	github.com/IBM/sarama v1.43.3
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/go-chi/chi/v5 v5.1.0
 	github.com/go-playground/validator/v10 v10.11.2
-	github.com/golang-jwt/jwt v3.2.2+incompatible
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/golangid/candi-plugin/task-queue-worker v0.0.0-20241022081437-59f56be28160
 	github.com/golangid/gojsonschema v0.0.1
 	github.com/golangid/graphql-go v0.0.9

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.11.2 h1:q3SHpufmypg+erIExEKUmsgmhDTyhcJ38oeKGACXohU=
 github.com/go-playground/validator/v10 v10.11.2/go.mod h1:NieE624vt4SCTJtD87arVLvdmjPAeV8BQlHtMnw9D7s=
-github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
-github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=

--- a/init.go
+++ b/init.go
@@ -2,5 +2,5 @@ package candi
 
 const (
 	// Version of this library
-	Version = "v1.18.2"
+	Version = "v1.18.3"
 )


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/74877c38-5fae-4222-bc12-df4883491e1c)

Due to a security concern raised in[ CVE-2024-51744](https://www.cve.org/CVERecord?id=CVE-2024-51744) and the outdatedness of the JWT library version, we need to update our JWT version to the latest one to ensure the application's security. This PR makes the necessary adjustments.

I am unsure if these changes will break the application, so I would appreciate it if you could review them
@golangid/candi-reviewer.

Additionally, please refer to the [migration guide](https://github.com/golang-jwt/jwt/blob/main/MIGRATION_GUIDE.md) for any related changes.