### PR TITLE
Fix make init Command: Handle Nil Pointer Dereference in Project Generator

### DIFF
--- a/cmd/candi/project_generator_utils.go
+++ b/cmd/candi/project_generator_utils.go
@@ -151,7 +151,9 @@ func loadSavedConfig(flagParam *flagParameter) serviceConfig {
 
 	b, err := os.ReadFile(baseDir + "candi.json")
 	if err != nil {
-		return serviceConfig{}
+		return serviceConfig{
+			flag: flagParam,
+		}
 	}
 	var savedConfig serviceConfig
 	json.Unmarshal(b, &savedConfig)
@@ -166,6 +168,7 @@ func loadSavedConfig(flagParam *flagParameter) serviceConfig {
 	savedConfig.Version = candi.Version
 	savedConfig.IsMonorepo = flagParam.isMonorepo
 	savedConfig.OutputDir = flagParam.outputFlag
+	savedConfig.flag = flagParam
 	return savedConfig
 }
 


### PR DESCRIPTION
#### Context
This PR resolves a runtime error encountered during the execution of the `make init` command. The issue arises when the `getRootDir` method in the `serviceConfig` struct returns a nil pointer, leading to a segmentation violation.

#### Root Cause
The panic occurs due to a nil pointer dereference at `/path/to/runner/candi/cmd/candi/types.go:126`. This impacts the `getNeedFileUpdates` function, which is invoked during the project generation process.

#### Changes Made
- Assigned the flag attribute to the `serviceConfig`

#### Steps to Reproduce
1. Run `make init` and follow the prompts to generate a new service.
2. Observe the segmentation fault when the project generator attempts to update files.

#### Testing
- Tested the `make init` command with various configurations to ensure proper initialization without errors.
- Verified that generated files and directories are created as expected.

#### References
- Error trace:
  ```
  panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x5b5049]
  ```
- Affected files:
  - `/cmd/candi/project_generator_utils.go`
